### PR TITLE
Do not treat default warnings as errors in _CoqProject

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -3,8 +3,6 @@
 -Q src AAC_tactics
 -I src
 
--arg -w -arg +default
-
 src/coq.mli
 src/helper.mli
 src/search_monad.mli


### PR DESCRIPTION
An important idea behind warnings is that a project's dependencies can mark stuff as deprecated or otherwise anti-recommended *before* removing that functionality, *without* requiring an atomic change across the two repositories. Another benefit of this design is that then we can use it to see all instances where a warning is triggered, instead of the build breaking on the first one. Treating warnings as errors even when others build the project with dependency versions that it wasn't developed on breaks this.

Now, you may want to do something other than exactly this PR. It is up to you whether you treat warnings as errors when building against release versions of your dependencies. But since there is no version-conditional logic in the Makefile right now, and this project is under coq-community, I am proposing the simplest change I can think of as opposed to the most fine-grained one.


Context: https://github.com/rocq-prover/stdlib/actions/runs/15409303789/job/43358101546?pr=162#step:12:249